### PR TITLE
Actually Transform formatArtworkURL

### DIFF
--- a/src/app/pipes/format-artwork-url.pipe.ts
+++ b/src/app/pipes/format-artwork-url.pipe.ts
@@ -1,4 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { stringInputToObject } from '@ctrl/tinycolor';
 
 declare var MusicKit: any;
 
@@ -7,11 +8,14 @@ declare var MusicKit: any;
 })
 export class FormatArtworkUrlPipe implements PipeTransform {
 
-  transform( artworkUrl: string, desiredDimension: number ): string {
-    if ( !artworkUrl ) {
+  transform(artworkUrl: string, desiredDimension: number): string {
+    if (!artworkUrl) {
       return './assets/default.jpeg';
     }
-    return MusicKit.formatArtworkURL( { 'url': artworkUrl }, desiredDimension, desiredDimension );
+    const re = new RegExp('[0-9]{2,4}x[0-9]{2,4}');
+    if (re.test(artworkUrl)) {
+      artworkUrl = artworkUrl.replace(re, desiredDimension.toString() + 'x' + desiredDimension.toString());
+    }
+    return MusicKit.formatArtworkURL({ 'url': artworkUrl }, desiredDimension, desiredDimension);
   }
-
 }


### PR DESCRIPTION
This fixes #8 and ensures that the requested image is exactly the size we need when transforming the URL. It also adds a small regex text to ensure we're only changing a valid 2-4 digit width x height in URL. It can also be changed to (desiredDimension * 2).toString()...) if you wanted to put in a multiplier for quality, but I didn't see any benefit to a 1:1 resolution and this keeps download size to a minimum.